### PR TITLE
Made these changes changes to memory-usage.js:

### DIFF
--- a/test/memory-usage.js
+++ b/test/memory-usage.js
@@ -1,29 +1,63 @@
-//test for memory leak after closing connections
+// Test for memory leak after closing connections.
 var ConnectionPool = require('../lib/connection-pool');
 var fs = require('fs');
 
-var count = 0;
-var mem = [];
+var connectionCount = 0;
+var currentGroup = 0;
+var memGroupsBytes = [];
+
 var groupCount = 20;
 var poolSize = 1000;
+var maxConnections = groupCount * poolSize;
 
-var pool = new ConnectionPool({ max: poolSize, min: poolSize, retryDelay: 1}, {
+// Print initial memory usage at program start.
+printMemoryUsage(0, process.memoryUsage().heapUsed, 1);
+
+for (i = 0; i < groupCount; i++) {
+    memGroupsBytes[i] = 0;
+}
+
+// Setup for connection failures.
+var pool = new ConnectionPool({ max: poolSize, min: poolSize, retryDelay: 1 }, {
     userName: 'testLogin',
     password: 'wrongPassword',
     server: 'localhost'
 });
 
-pool.on('error', function() {
-    var i = Math.floor(count++ / poolSize);
-    if (i === groupCount) {
-        var previous = 0;
-        for (var f = 0; f < groupCount; f++) {
-            var size = (mem[f] / poolSize);
-            fs.writeSync(1, ((f + 1) * poolSize) + ': ' + Math.round(mem[f] / poolSize * 100) + 'KB\n');
-            global.gc();
-            previous = size;
+pool.on('error', function () {
+    var isNewPool = (++connectionCount % poolSize) == 0;
+    memGroupsBytes[currentGroup] += process.memoryUsage().heapUsed;
+
+    if (isNewPool) {
+        printMemoryUsage(connectionCount, memGroupsBytes[currentGroup], poolSize);
+        currentGroup++;
+        global.gc();
+    }
+
+    if (connectionCount === maxConnections) {
+        // Validation to detect memory leaks.
+        var memNoiseThresholdKB = 2 * 1024;
+
+        memGroupsBytes.sort(function (a, b) {
+            return a - b;
+        });
+
+        var maxMemDeltaKB = Math.round((memGroupsBytes[groupCount - 1] - memGroupsBytes[0]) / poolSize / 1024);
+
+        if (maxMemDeltaKB > memNoiseThresholdKB) {
+            fs.writeSync(2, '\nMemory leak detected during ' + maxConnections + ' failed connections.\n');
+            fs.writeSync(2, 'Max memory delta(=' + maxMemDeltaKB + 'KB) > Threshold(=' + memNoiseThresholdKB + 'KB)\n');
         }
+        else {
+            fs.writeSync(1, '\nMemory leak not detected during ' + maxConnections + ' failed connections.\n');
+            fs.writeSync(1, 'Max memory delta(=' + maxMemDeltaKB + 'KB) < Threshold(=' + memNoiseThresholdKB + 'KB)\n');
+        }
+
         process.exit(0);
     }
-    mem[i] = (mem[i] || 0) + (process.memoryUsage().heapUsed / 1000); //kilobytes
 });
+
+function printMemoryUsage(connectionCount, cumulativeMemoryUsageBytes, numMemoryUsagesCount) {
+    var memoryUsageKB = Math.round(cumulativeMemoryUsageBytes / numMemoryUsagesCount / 1024);
+    fs.writeSync(1, connectionCount + ': ' + memoryUsageKB + 'KB\n');
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
1. Run global.gc() after every poolSize of connection attempts instead of at the end.
2. Change KB computation to use 1024 instead of 1000 and 100 as it does now.
3. Add validation at the end of test run to see if the memory usage increase is within a threshold.

## Related Issue
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue here: -->
https://github.com/tediousjs/tedious-connection-pool/issues/38

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Test imrovement.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
node --expose-gc test\memory-usage.js
<!-- Include details of your testing environment, and the tests you ran to -->
Node: v0.12.2
Windows: 10.0.10586
<!-- see how your change affects other areas of the code, etc. -->
No functional change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

1) Run global.gc() after every poolSize of connection failures.
2) Print memory usage after every poolSize of connection failures.
3) Do validation at the end to see if there is memory leak.